### PR TITLE
release: v0.2.0 — writer support for XTC and TRR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.2.0] - 2026-03-23
+
+### Added
+
+- **TRR writer** with frame-by-frame writing and append mode (#17)
+- **XTC writer** with full coordinate compression algorithm (#18)
+- Cross-format conversion tests and mdtraj validation script (#19)
+- Converter CLI tool for TRR↔XTC conversion
+- Append mode for both writers with natoms validation against existing files
+- Frame data validation in writers (array length, null checks, natoms bounds)
+
+### Changed
+
+- Refactored XTC encoding utilities (`sizeofint`, `sizeofints`, `decodebits`, `decodeints`) from `XtcReader` methods to module-level functions for reader/writer reuse
+- TRR writer header writes batched into a single 84-byte buffer write
+- TRR `writeFloatsBulk` chunk size increased from 1024 to 4096 floats
+- CI now runs validation tests as a separate sequential step to avoid parallel file conflicts
+- README rewritten with complete reader/writer API documentation
+
+### Fixed
+
+- `close()` in both writers now releases all resources before returning flush errors (#17, #18)
+- `encodebits` bit masks added to match C reference implementation (#18)
+- XTC compression bounds check: guard `smallidx` against `LASTIDX` overflow (#18)
+- Invalid precision (≤ 0) now returns error instead of silent fallback to 1000 (#18)
+- Parallel test file conflicts resolved with unique tmp path prefixes per module (#21)
+
+### Performance
+
+- TRR writer: ~900 MB/s throughput (read+write combined on M4 Pro)
+- XTC writer: ~280 MB/s throughput (compression-bound)
+
 ## [0.1.1] - 2026-03-11
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,20 +4,21 @@
 [![CI](https://github.com/N283T/zxdrfile/actions/workflows/ci.yml/badge.svg)](https://github.com/N283T/zxdrfile/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-BSD_2--Clause-blue.svg)](LICENSE)
 
-A Zig library for reading and writing GROMACS XDR trajectory files (XTC and TRR formats).
+A high-performance Zig library for reading and writing GROMACS XDR trajectory files (XTC and TRR formats).
 
 [**API Documentation**](https://n283t.github.io/zxdrfile/)
 
 ## Features
 
-- **XTC reader/writer** -- Compressed trajectory format with 3D coordinate compression/decompression
-- **TRR reader/writer** -- Uncompressed trajectory format with coordinates, velocities, and forces
-- **High performance** -- Buffered I/O with bulk reads and in-place byte-swapping
-- **Zero dependencies** -- Pure Zig, no C bindings required
+- **XTC reader/writer** -- Compressed coordinate trajectories with lossy 3D compression
+- **TRR reader/writer** -- Full-precision trajectories with coordinates, velocities, and forces
+- **High performance** -- Buffered I/O, bulk byte-swapping, batched header writes
+- **Zero dependencies** -- Pure Zig implementation, no C bindings required
+- **Append mode** -- Append frames to existing trajectory files with natoms validation
 
-## Usage
+## Installation
 
-Add as a Zig package dependency in your `build.zig.zon`:
+Add as a dependency in your `build.zig.zon`:
 
 ```zon
 .dependencies = .{
@@ -35,11 +36,14 @@ const zxdrfile = b.dependency("zxdrfile", .{ .target = target, .optimize = optim
 mod.addImport("zxdrfile", zxdrfile.module("zxdrfile"));
 ```
 
-### Reading XTC
+## Quick Start
+
+### Reading
 
 ```zig
 const xdrfile = @import("zxdrfile");
 
+// XTC
 var reader = try xdrfile.XtcReader.open(allocator, "trajectory.xtc");
 defer reader.close();
 
@@ -49,16 +53,10 @@ while (true) {
         return err;
     };
     defer frame.deinit(allocator);
-
     // frame.step, frame.time, frame.box, frame.coords, frame.precision
 }
-```
 
-### Reading TRR
-
-```zig
-const xdrfile = @import("zxdrfile");
-
+// TRR
 var reader = try xdrfile.TrrReader.open(allocator, "trajectory.trr");
 defer reader.close();
 
@@ -68,21 +66,33 @@ while (true) {
         return err;
     };
     defer frame.deinit(allocator);
-
     // frame.step, frame.time, frame.lambda, frame.box
-    // frame.coords, frame.velocities, frame.forces (optional, nullable)
+    // frame.coords, frame.velocities, frame.forces (optional)
 }
 ```
 
-### Writing TRR
+### Writing
 
 ```zig
 const xdrfile = @import("zxdrfile");
 
+// XTC (lossy compression — precision controls accuracy)
+var writer = try xdrfile.XtcWriter.open(allocator, "output.xtc", natoms, .write);
+defer writer.close() catch {};
+
+try writer.writeFrame(.{
+    .step = 0,
+    .time = 0.0,
+    .box = box,
+    .coords = coords,
+    .precision = 1000.0, // ~0.001 nm accuracy
+});
+
+// TRR (lossless)
 var writer = try xdrfile.TrrWriter.open(allocator, "output.trr", natoms, .write);
 defer writer.close() catch {};
 
-const frame = xdrfile.TrrFrame{
+try writer.writeFrame(.{
     .step = 0,
     .time = 0.0,
     .lambda = 0.0,
@@ -93,43 +103,19 @@ const frame = xdrfile.TrrFrame{
     .coords = coords,
     .velocities = null,
     .forces = null,
-};
-try writer.writeFrame(frame);
-```
+});
 
-To append to an existing file, use `.append` mode:
-
-```zig
+// Append to existing file
 var writer = try xdrfile.TrrWriter.open(allocator, "existing.trr", natoms, .append);
 ```
-
-### Writing XTC
-
-```zig
-const xdrfile = @import("zxdrfile");
-
-var writer = try xdrfile.XtcWriter.open(allocator, "output.xtc", natoms, .write);
-defer writer.close() catch {};
-
-const frame = xdrfile.XtcFrame{
-    .step = 0,
-    .time = 0.0,
-    .box = box,
-    .coords = coords,
-    .precision = 1000.0,
-};
-try writer.writeFrame(frame);
-```
-
-> **Note:** XTC uses lossy compression. The `precision` parameter controls the trade-off
-> between file size and coordinate accuracy (1000.0 gives ~0.001 nm accuracy).
 
 ## Building
 
 ```bash
-zig build test      # Run unit tests + validation tests
-zig build validate  # Run validation tests only (against mdtraj reference)
-zig build bench     # Run benchmarks (ReleaseFast)
+zig build test         # Run unit tests
+zig build validate     # Run validation tests (against mdtraj reference)
+zig build cross-format # Run cross-format conversion tests
+zig build bench        # Run benchmarks (ReleaseFast)
 ```
 
 ## Requirements
@@ -139,18 +125,6 @@ zig build bench     # Run benchmarks (ReleaseFast)
 > **Note:** Zig has not yet reached 1.0 and its standard library API changes
 > frequently between versions. This library may not compile on versions other
 > than the one specified above. Check the CI status badge for current compatibility.
-
-## Differences from the Original C Library
-
-This is not a line-by-line translation. Key differences:
-
-- **Full read/write support** -- Both XTC and TRR formats support reading and writing
-- **Zig-native error handling** -- Uses Zig's error union types instead of C-style return codes
-- **Allocator-aware** -- All memory allocation goes through a caller-provided `std.mem.Allocator`
-- **Buffered I/O** -- 64KB read buffer via `std.fs.File.Reader`, reducing syscall overhead
-- **Bulk reads with in-place byte-swap** -- TRR vectors are read in a single call and byte-swapped in place, instead of one-element-at-a-time XDR decoding
-- **Overflow-safe arithmetic** -- Uses `std.math.mul` for bounds checking on atom count calculations
-- **Bounds checks on smallidx** -- Validates compression index against `FIRSTIDX`/`LASTIDX` to prevent out-of-bounds access
 
 ## Performance
 
@@ -165,7 +139,7 @@ C reference uses the original xdrfile library from mdtraj, compiled with `-O2`.
 | 5wvo_C | 3,858 | 1,001 | 17 MB | 261 MB/s | 246 MB/s | 1.1x |
 | 6sup_A | 33,377 | 1,001 | 148 MB | 321 MB/s | 284 MB/s | 1.1x |
 
-XTC performance is comparable to C. The decompression algorithm dominates runtime,
+XTC performance is comparable to C. The compression algorithm dominates runtime,
 so I/O optimizations have limited impact.
 
 ### TRR (uncompressed)
@@ -178,6 +152,19 @@ so I/O optimizations have limited impact.
 
 TRR is dramatically faster because the C library decodes each 4-byte value individually
 via XDR function calls, while zxdrfile reads entire vectors in bulk and byte-swaps in place.
+
+## Differences from the Original C Library
+
+This is not a line-by-line translation. Key differences:
+
+- **Full read/write support** -- Both XTC and TRR formats support reading and writing
+- **Zig-native error handling** -- Uses Zig's error union types instead of C-style return codes
+- **Allocator-aware** -- All memory allocation goes through a caller-provided `std.mem.Allocator`
+- **Buffered I/O** -- 64KB buffer for both reads and writes, reducing syscall overhead
+- **Bulk byte-swapping** -- Reads/writes entire vectors at once with in-place byte-swap
+- **Batched header writes** -- TRR header packed into a single buffer write
+- **Overflow-safe arithmetic** -- Uses `std.math.mul` for bounds checking on atom count calculations
+- **Compression bounds checks** -- Validates `smallidx` against `FIRSTIDX`/`LASTIDX` to prevent out-of-bounds access
 
 ## Acknowledgments
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zxdrfile,
-    .version = "0.1.1",
+    .version = "0.2.0",
     .fingerprint = 0x3a99db92f6908624,
     .minimum_zig_version = "0.15.2",
     .paths = .{


### PR DESCRIPTION
## Summary

Version bump to 0.2.0 with full writer support.

### What's new in 0.2.0
- **TRR writer** with frame-by-frame writing and append mode
- **XTC writer** with full coordinate compression algorithm
- Cross-format conversion tests with mdtraj validation
- Performance optimizations (batched header writes, larger chunk sizes)

### This PR
- Rewritten README with complete API documentation
- CHANGELOG entry for 0.2.0
- Version bump in build.zig.zon

See CHANGELOG.md for full details.