### PR TITLE
feat!: Zig 0.16 migration (std.Io API; BREAKING)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Run tests
         run: zig build test

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Generate docs
         run: zig build docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.3.0] - 2026-04-26
+
+### Changed (BREAKING)
+
+- **Zig 0.16 required**: bumped `minimum_zig_version` from `0.15.2` to `0.16.0`
+- **Public API now takes `std.Io`**: as part of the Zig 0.16 unified I/O interface (`std.Io`), all reader/writer entry points have a new first parameter:
+  - `XtcReader.open(io, allocator, path)`
+  - `XtcWriter.open(io, allocator, path, natoms, mode)`
+  - `TrrReader.open(io, allocator, path)`
+  - `TrrWriter.open(io, allocator, path, natoms, mode)`
+  Obtain `io` from `std.process.Init.io` in your `main` (recommended) or by initializing `std.Io.Threaded`.
+- `converter` and `benchmark` migrated to the new `pub fn main(init: std.process.Init)` entry-point convention.
+- Internal types: `std.fs.File` → `std.Io.File`, `std.io.Reader` → `std.Io.Reader`.
+
+### Migration
+
+```zig
+// 0.2.x
+var reader = try XtcReader.open(allocator, "traj.xtc");
+
+// 0.3.0
+var reader = try XtcReader.open(io, allocator, "traj.xtc");
+```
+
+In tests, use `std.testing.io` as the `io` argument.
+
 ## [0.2.0] - 2026-03-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,19 +16,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   - `TrrWriter.open(io, allocator, path, natoms, mode)`
   Obtain `io` from `std.process.Init.io` in your `main` (recommended) or by initializing `std.Io.Threaded`.
 - `converter` and `benchmark` migrated to the new `pub fn main(init: std.process.Init)` entry-point convention.
-- Internal types: `std.fs.File` → `std.Io.File`, `std.io.Reader` → `std.Io.Reader`.
+- Internal types and APIs:
+  - `std.fs.File` / `std.fs.cwd()` → `std.Io.File` / `std.Io.Dir.cwd()`
+  - `std.io.Reader` / `std.io.Writer` → `std.Io.Reader` / `std.Io.Writer`
+  - `file.getEndPos()` → `file.length(io)`
+  - `file.seekTo(0)` (on the File) → `reader.seekTo(0)` (on the buffered Reader)
+  - `std.time.Timer` → `std.Io.Timestamp` with `Clock.awake`
+  - `std.heap.GeneralPurposeAllocator` → `std.heap.DebugAllocator`
+  - `std.process.argsAlloc/argsFree` → `std.process.Init.minimal.args.toSlice(arena)`
 
 ### Migration
 
 ```zig
 // 0.2.x
 var reader = try XtcReader.open(allocator, "traj.xtc");
+var writer = try XtcWriter.open(allocator, "out.xtc", natoms, .write);
 
 // 0.3.0
 var reader = try XtcReader.open(io, allocator, "traj.xtc");
+var writer = try XtcWriter.open(io, allocator, "out.xtc", natoms, .write);
 ```
 
-In tests, use `std.testing.io` as the `io` argument.
+In tests, use `std.testing.io` as the `io` argument. In binaries, take
+`init: std.process.Init` as the `main` parameter and use `init.io`.
 
 ## [0.2.0] - 2026-03-23
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # zxdrfile
 
-[![Zig](https://img.shields.io/badge/Zig-0.15.2+-f7a41d?logo=zig&logoColor=white)](https://ziglang.org/)
+[![Zig](https://img.shields.io/badge/Zig-0.16.0+-f7a41d?logo=zig&logoColor=white)](https://ziglang.org/)
 [![CI](https://github.com/N283T/zxdrfile/actions/workflows/ci.yml/badge.svg)](https://github.com/N283T/zxdrfile/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-BSD_2--Clause-blue.svg)](LICENSE)
 
@@ -38,13 +38,27 @@ mod.addImport("zxdrfile", zxdrfile.module("zxdrfile"));
 
 ## Quick Start
 
+All reader/writer entry points take `io: std.Io` as their first argument
+(Zig 0.16's unified I/O interface). Obtain `io` from `std.process.Init.io`
+in your `main`:
+
+```zig
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+    const allocator = init.gpa;
+    // ... use io and allocator ...
+}
+```
+
+In tests, use `std.testing.io`.
+
 ### Reading
 
 ```zig
 const xdrfile = @import("zxdrfile");
 
 // XTC
-var reader = try xdrfile.XtcReader.open(allocator, "trajectory.xtc");
+var reader = try xdrfile.XtcReader.open(io, allocator, "trajectory.xtc");
 defer reader.close();
 
 while (true) {
@@ -57,7 +71,7 @@ while (true) {
 }
 
 // TRR
-var reader = try xdrfile.TrrReader.open(allocator, "trajectory.trr");
+var reader = try xdrfile.TrrReader.open(io, allocator, "trajectory.trr");
 defer reader.close();
 
 while (true) {
@@ -77,7 +91,7 @@ while (true) {
 const xdrfile = @import("zxdrfile");
 
 // XTC (lossy compression — precision controls accuracy)
-var writer = try xdrfile.XtcWriter.open(allocator, "output.xtc", natoms, .write);
+var writer = try xdrfile.XtcWriter.open(io, allocator, "output.xtc", natoms, .write);
 defer writer.close() catch {};
 
 try writer.writeFrame(.{
@@ -89,7 +103,7 @@ try writer.writeFrame(.{
 });
 
 // TRR (lossless)
-var writer = try xdrfile.TrrWriter.open(allocator, "output.trr", natoms, .write);
+var writer = try xdrfile.TrrWriter.open(io, allocator, "output.trr", natoms, .write);
 defer writer.close() catch {};
 
 try writer.writeFrame(.{
@@ -106,7 +120,7 @@ try writer.writeFrame(.{
 });
 
 // Append to existing file
-var writer = try xdrfile.TrrWriter.open(allocator, "existing.trr", natoms, .append);
+var writer = try xdrfile.TrrWriter.open(io, allocator, "existing.trr", natoms, .append);
 ```
 
 ## Building
@@ -120,7 +134,7 @@ zig build bench        # Run benchmarks (ReleaseFast)
 
 ## Requirements
 
-- Zig 0.15.2 or later
+- Zig 0.16.0 or later
 
 > **Note:** Zig has not yet reached 1.0 and its standard library API changes
 > frequently between versions. This library may not compile on versions other

--- a/README.md
+++ b/README.md
@@ -46,7 +46,12 @@ in your `main`:
 pub fn main(init: std.process.Init) !void {
     const io = init.io;
     const allocator = init.gpa;
-    // ... use io and allocator ...
+
+    // Command-line args (sentinel-terminated strings):
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
+    _ = args;
+
+    // ... use io and allocator with the readers/writers below ...
 }
 ```
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,8 +1,8 @@
 .{
     .name = .zxdrfile,
-    .version = "0.2.0",
+    .version = "0.3.0",
     .fingerprint = 0x3a99db92f6908624,
-    .minimum_zig_version = "0.15.2",
+    .minimum_zig_version = "0.16.0",
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -36,11 +36,8 @@ const Reference = struct {
     sample_frames: std.json.ArrayHashMap(SampleFrame),
 };
 
-fn loadReference(allocator: std.mem.Allocator, path: []const u8) !?std.json.Parsed(Reference) {
-    const file = std.fs.cwd().openFile(path, .{}) catch return null;
-    defer file.close();
-
-    const data = file.readToEndAlloc(allocator, 64 * 1024 * 1024) catch return null;
+fn loadReference(io: std.Io, allocator: std.mem.Allocator, path: []const u8) !?std.json.Parsed(Reference) {
+    const data = std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(64 * 1024 * 1024)) catch return null;
     defer allocator.free(data);
 
     return std.json.parseFromSlice(Reference, allocator, data, .{
@@ -59,9 +56,15 @@ fn validateFrame(coords: []f32, ref_coords: []f64, tolerance: f32) bool {
     return true;
 }
 
-fn benchmarkXtc(allocator: std.mem.Allocator, path: []const u8, name: []const u8, ref_path: ?[]const u8) !?BenchResult {
+fn elapsedMs(io: std.Io, start: std.Io.Timestamp) f64 {
+    const end = std.Io.Timestamp.now(io, .awake);
+    const duration = start.durationTo(end);
+    return @as(f64, @floatFromInt(@as(i64, @intCast(duration.nanoseconds)))) / 1_000_000.0;
+}
+
+fn benchmarkXtc(io: std.Io, allocator: std.mem.Allocator, path: []const u8, name: []const u8, ref_path: ?[]const u8) !?BenchResult {
     const file_size = blk: {
-        const stat = std.fs.cwd().statFile(path) catch return null;
+        const stat = std.Io.Dir.cwd().statFile(io, path, .{}) catch return null;
         break :blk stat.size;
     };
 
@@ -69,10 +72,10 @@ fn benchmarkXtc(allocator: std.mem.Allocator, path: []const u8, name: []const u8
     var parsed_ref: ?std.json.Parsed(Reference) = null;
     defer if (parsed_ref) |*p| p.deinit();
     if (ref_path) |rp| {
-        parsed_ref = try loadReference(allocator, rp);
+        parsed_ref = try loadReference(io, allocator, rp);
     }
 
-    var reader = XtcReader.open(allocator, path) catch return null;
+    var reader = XtcReader.open(io, allocator, path) catch return null;
     defer reader.close();
 
     const natoms = reader.getNumAtoms();
@@ -80,7 +83,7 @@ fn benchmarkXtc(allocator: std.mem.Allocator, path: []const u8, name: []const u8
     const validated = parsed_ref != null;
     var validation_ok = true;
 
-    var timer = try std.time.Timer.start();
+    const start = std.Io.Timestamp.now(io, .awake);
 
     while (true) {
         var frame = reader.readFrame() catch |err| {
@@ -103,8 +106,7 @@ fn benchmarkXtc(allocator: std.mem.Allocator, path: []const u8, name: []const u8
         n_frames += 1;
     }
 
-    const elapsed_ns = timer.read();
-    const elapsed_ms = @as(f64, @floatFromInt(elapsed_ns)) / 1_000_000.0;
+    const elapsed_ms = elapsedMs(io, start);
     const file_size_mb = @as(f64, @floatFromInt(file_size)) / (1024.0 * 1024.0);
     const throughput = file_size_mb / (elapsed_ms / 1000.0);
     const fps = @as(f64, @floatFromInt(n_frames)) / (elapsed_ms / 1000.0);
@@ -129,19 +131,19 @@ fn benchmarkXtc(allocator: std.mem.Allocator, path: []const u8, name: []const u8
     };
 }
 
-fn benchmarkTrr(allocator: std.mem.Allocator, path: []const u8, name: []const u8, ref_path: ?[]const u8) !?BenchResult {
+fn benchmarkTrr(io: std.Io, allocator: std.mem.Allocator, path: []const u8, name: []const u8, ref_path: ?[]const u8) !?BenchResult {
     const file_size = blk: {
-        const stat = std.fs.cwd().statFile(path) catch return null;
+        const stat = std.Io.Dir.cwd().statFile(io, path, .{}) catch return null;
         break :blk stat.size;
     };
 
     var parsed_ref: ?std.json.Parsed(Reference) = null;
     defer if (parsed_ref) |*p| p.deinit();
     if (ref_path) |rp| {
-        parsed_ref = try loadReference(allocator, rp);
+        parsed_ref = try loadReference(io, allocator, rp);
     }
 
-    var reader = TrrReader.open(allocator, path) catch return null;
+    var reader = TrrReader.open(io, allocator, path) catch return null;
     defer reader.close();
 
     const natoms = reader.getNumAtoms();
@@ -149,7 +151,7 @@ fn benchmarkTrr(allocator: std.mem.Allocator, path: []const u8, name: []const u8
     const validated = parsed_ref != null;
     var validation_ok = true;
 
-    var timer = try std.time.Timer.start();
+    const start = std.Io.Timestamp.now(io, .awake);
 
     while (true) {
         var frame = reader.readFrame() catch |err| {
@@ -174,8 +176,7 @@ fn benchmarkTrr(allocator: std.mem.Allocator, path: []const u8, name: []const u8
         n_frames += 1;
     }
 
-    const elapsed_ns = timer.read();
-    const elapsed_ms = @as(f64, @floatFromInt(elapsed_ns)) / 1_000_000.0;
+    const elapsed_ms = elapsedMs(io, start);
     const file_size_mb = @as(f64, @floatFromInt(file_size)) / (1024.0 * 1024.0);
     const throughput = file_size_mb / (elapsed_ms / 1000.0);
     const fps = @as(f64, @floatFromInt(n_frames)) / (elapsed_ms / 1000.0);
@@ -219,10 +220,9 @@ const BenchEntry = struct {
     ref_path: ?[]const u8 = null,
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
+    const io = init.io;
 
     std.debug.print("\n=== zxdrfile benchmark ===\n\n", .{});
 
@@ -234,7 +234,7 @@ pub fn main() !void {
         .{ .path = "benchmarks/md_data/6sup_A_R1.xtc", .name = "6sup_A (33377 atoms)", .ref_path = "benchmarks/reference/6sup_A_R1_xtc_reference.json" },
     };
     for (xtc_files) |f| {
-        if (try benchmarkXtc(allocator, f.path, f.name, f.ref_path)) |r| {
+        if (try benchmarkXtc(io, allocator, f.path, f.name, f.ref_path)) |r| {
             printResult(r);
         }
     }
@@ -247,7 +247,7 @@ pub fn main() !void {
         .{ .path = "benchmarks/md_data/6sup_A_R1.trr", .name = "6sup_A (33377 atoms)", .ref_path = "benchmarks/reference/6sup_A_R1_trr_reference.json" },
     };
     for (trr_files) |f| {
-        if (try benchmarkTrr(allocator, f.path, f.name, f.ref_path)) |r| {
+        if (try benchmarkTrr(io, allocator, f.path, f.name, f.ref_path)) |r| {
             printResult(r);
         }
     }

--- a/src/converter.zig
+++ b/src/converter.zig
@@ -4,13 +4,11 @@
 const std = @import("std");
 const xdrfile = @import("xdrfile.zig");
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
+    const io = init.io;
 
-    const args = try std.process.argsAlloc(allocator);
-    defer std.process.argsFree(allocator, args);
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
 
     if (args.len != 4) {
         std.debug.print("Usage: converter <trr_to_xtc|xtc_to_trr> <input> <output>\n", .{});
@@ -22,20 +20,20 @@ pub fn main() !void {
     const output_path = args[3];
 
     if (std.mem.eql(u8, mode, "trr_to_xtc")) {
-        try convertTrrToXtc(allocator, input_path, output_path);
+        try convertTrrToXtc(io, allocator, input_path, output_path);
     } else if (std.mem.eql(u8, mode, "xtc_to_trr")) {
-        try convertXtcToTrr(allocator, input_path, output_path);
+        try convertXtcToTrr(io, allocator, input_path, output_path);
     } else {
         std.debug.print("Unknown mode: {s}\n", .{mode});
         std.process.exit(1);
     }
 }
 
-fn convertTrrToXtc(allocator: std.mem.Allocator, input: []const u8, output: []const u8) !void {
-    var reader = try xdrfile.TrrReader.open(allocator, input);
+fn convertTrrToXtc(io: std.Io, allocator: std.mem.Allocator, input: []const u8, output: []const u8) !void {
+    var reader = try xdrfile.TrrReader.open(io, allocator, input);
     defer reader.close();
 
-    var writer = try xdrfile.XtcWriter.open(allocator, output, reader.getNumAtoms(), .write);
+    var writer = try xdrfile.XtcWriter.open(io, allocator, output, reader.getNumAtoms(), .write);
     defer writer.close() catch {};
 
     var count: usize = 0;
@@ -58,11 +56,11 @@ fn convertTrrToXtc(allocator: std.mem.Allocator, input: []const u8, output: []co
     std.debug.print("Converted {d} frames: TRR → XTC\n", .{count});
 }
 
-fn convertXtcToTrr(allocator: std.mem.Allocator, input: []const u8, output: []const u8) !void {
-    var reader = try xdrfile.XtcReader.open(allocator, input);
+fn convertXtcToTrr(io: std.Io, allocator: std.mem.Allocator, input: []const u8, output: []const u8) !void {
+    var reader = try xdrfile.XtcReader.open(io, allocator, input);
     defer reader.close();
 
-    var writer = try xdrfile.TrrWriter.open(allocator, output, reader.getNumAtoms(), .write);
+    var writer = try xdrfile.TrrWriter.open(io, allocator, output, reader.getNumAtoms(), .write);
     defer writer.close() catch {};
 
     var count: usize = 0;

--- a/src/cross_format_test.zig
+++ b/src/cross_format_test.zig
@@ -28,11 +28,11 @@ test "TRR → XTC → read back" {
     var natoms: i32 = 0;
     var frame_count: usize = 0;
     {
-        var reader = try TrrReader.open(allocator, "test_data/frame0.trr");
+        var reader = try TrrReader.open(std.testing.io, allocator, "test_data/frame0.trr");
         defer reader.close();
         natoms = reader.getNumAtoms();
 
-        var writer = try XtcWriter.open(allocator, xtc_path, natoms, .write);
+        var writer = try XtcWriter.open(std.testing.io, allocator, xtc_path, natoms, .write);
         defer writer.close() catch {};
 
         while (true) {
@@ -53,18 +53,18 @@ test "TRR → XTC → read back" {
             frame_count += 1;
         }
     }
-    defer std.fs.cwd().deleteFile(xtc_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, xtc_path) catch {};
 
     try std.testing.expectEqual(@as(usize, 501), frame_count);
 
     // Read back XTC and verify
-    var xtc_reader = try XtcReader.open(allocator, xtc_path);
+    var xtc_reader = try XtcReader.open(std.testing.io, allocator, xtc_path);
     defer xtc_reader.close();
 
     try std.testing.expectEqual(natoms, xtc_reader.getNumAtoms());
 
     // Also re-read TRR for comparison
-    var trr_reader = try TrrReader.open(allocator, "test_data/frame0.trr");
+    var trr_reader = try TrrReader.open(std.testing.io, allocator, "test_data/frame0.trr");
     defer trr_reader.close();
 
     const tolerance: f32 = 1.0 / precision + 0.001;
@@ -104,11 +104,11 @@ test "XTC → TRR → read back" {
     var natoms: i32 = 0;
     var frame_count: usize = 0;
     {
-        var reader = try XtcReader.open(allocator, "test_data/1l2y.xtc");
+        var reader = try XtcReader.open(std.testing.io, allocator, "test_data/1l2y.xtc");
         defer reader.close();
         natoms = reader.getNumAtoms();
 
-        var writer = try TrrWriter.open(allocator, trr_path, natoms, .write);
+        var writer = try TrrWriter.open(std.testing.io, allocator, trr_path, natoms, .write);
         defer writer.close() catch {};
 
         while (true) {
@@ -134,15 +134,15 @@ test "XTC → TRR → read back" {
             frame_count += 1;
         }
     }
-    defer std.fs.cwd().deleteFile(trr_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, trr_path) catch {};
 
     try std.testing.expectEqual(@as(usize, 38), frame_count);
 
     // Read back TRR and compare with original XTC
-    var xtc_reader = try XtcReader.open(allocator, "test_data/1l2y.xtc");
+    var xtc_reader = try XtcReader.open(std.testing.io, allocator, "test_data/1l2y.xtc");
     defer xtc_reader.close();
 
-    var trr_reader = try TrrReader.open(allocator, trr_path);
+    var trr_reader = try TrrReader.open(std.testing.io, allocator, trr_path);
     defer trr_reader.close();
 
     try std.testing.expectEqual(natoms, trr_reader.getNumAtoms());
@@ -185,11 +185,11 @@ test "TRR → XTC → TRR round-trip" {
 
     // Step 1: TRR → XTC
     {
-        var reader = try TrrReader.open(allocator, "test_data/frame0.trr");
+        var reader = try TrrReader.open(std.testing.io, allocator, "test_data/frame0.trr");
         defer reader.close();
         natoms = reader.getNumAtoms();
 
-        var writer = try XtcWriter.open(allocator, xtc_path, natoms, .write);
+        var writer = try XtcWriter.open(std.testing.io, allocator, xtc_path, natoms, .write);
         defer writer.close() catch {};
 
         while (true) {
@@ -207,14 +207,14 @@ test "TRR → XTC → TRR round-trip" {
             });
         }
     }
-    defer std.fs.cwd().deleteFile(xtc_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, xtc_path) catch {};
 
     // Step 2: XTC → TRR
     {
-        var reader = try XtcReader.open(allocator, xtc_path);
+        var reader = try XtcReader.open(std.testing.io, allocator, xtc_path);
         defer reader.close();
 
-        var writer = try TrrWriter.open(allocator, trr_path, natoms, .write);
+        var writer = try TrrWriter.open(std.testing.io, allocator, trr_path, natoms, .write);
         defer writer.close() catch {};
 
         while (true) {
@@ -237,13 +237,13 @@ test "TRR → XTC → TRR round-trip" {
             });
         }
     }
-    defer std.fs.cwd().deleteFile(trr_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, trr_path) catch {};
 
     // Step 3: Compare original TRR with TRR-via-XTC
-    var orig_reader = try TrrReader.open(allocator, "test_data/frame0.trr");
+    var orig_reader = try TrrReader.open(std.testing.io, allocator, "test_data/frame0.trr");
     defer orig_reader.close();
 
-    var conv_reader = try TrrReader.open(allocator, trr_path);
+    var conv_reader = try TrrReader.open(std.testing.io, allocator, trr_path);
     defer conv_reader.close();
 
     const tolerance: f32 = 1.0 / precision + 0.001;

--- a/src/validation_test.zig
+++ b/src/validation_test.zig
@@ -25,10 +25,7 @@ const Reference = struct {
 };
 
 fn parseReference(allocator: std.mem.Allocator, path: []const u8) !std.json.Parsed(Reference) {
-    const file = try std.fs.cwd().openFile(path, .{});
-    defer file.close();
-
-    const data = try file.readToEndAlloc(allocator, 64 * 1024 * 1024);
+    const data = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, path, allocator, .limited(64 * 1024 * 1024));
     defer allocator.free(data);
 
     return std.json.parseFromSlice(Reference, allocator, data, .{ .allocate = .alloc_always });
@@ -49,7 +46,7 @@ test "validate XTC against mdtraj reference" {
     defer parsed.deinit();
     const ref = parsed.value;
 
-    var reader = try XtcReader.open(allocator, "test_data/1l2y.xtc");
+    var reader = try XtcReader.open(std.testing.io, allocator, "test_data/1l2y.xtc");
     defer reader.close();
 
     try std.testing.expectEqual(@as(i32, @intCast(ref.natoms)), reader.getNumAtoms());
@@ -98,7 +95,7 @@ test "validate TRR against mdtraj reference" {
     defer parsed.deinit();
     const ref = parsed.value;
 
-    var reader = try TrrReader.open(allocator, "test_data/frame0.trr");
+    var reader = try TrrReader.open(std.testing.io, allocator, "test_data/frame0.trr");
     defer reader.close();
 
     try std.testing.expectEqual(@as(i32, @intCast(ref.natoms)), reader.getNumAtoms());

--- a/src/xdrfile_trr.zig
+++ b/src/xdrfile_trr.zig
@@ -96,46 +96,47 @@ pub const TrrFrame = struct {
 
 /// TRR file reader
 pub const TrrReader = struct {
-    file: std.fs.File,
-    reader: std.fs.File.Reader,
+    io_handle: std.Io,
+    file: std.Io.File,
+    reader: std.Io.File.Reader,
     read_buf: *[READ_BUF_SIZE]u8,
     allocator: Allocator,
     natoms: i32,
 
     const Self = @This();
 
-    pub fn open(allocator: Allocator, path: []const u8) !Self {
-        const file = std.fs.cwd().openFile(path, .{}) catch {
+    pub fn open(io_handle: std.Io, allocator: Allocator, path: []const u8) !Self {
+        const file = std.Io.Dir.cwd().openFile(io_handle, path, .{}) catch {
             return TrrError.FileNotFound;
         };
-        errdefer file.close();
+        errdefer file.close(io_handle);
 
         const read_buf = allocator.create([READ_BUF_SIZE]u8) catch return TrrError.OutOfMemory;
         errdefer allocator.destroy(read_buf);
 
         var self = Self{
+            .io_handle = io_handle,
             .file = file,
             .reader = undefined,
             .read_buf = read_buf,
             .allocator = allocator,
             .natoms = 0,
         };
-        self.reader = file.reader(read_buf);
+        self.reader = file.reader(io_handle, read_buf);
 
         // Read first header to get natoms
         const header = try self.readHeader();
         self.natoms = header.natoms;
 
         // Reset to beginning
-        file.seekTo(0) catch return TrrError.ReadError;
-        self.reader = file.reader(read_buf);
+        self.reader.seekTo(0) catch return TrrError.ReadError;
 
         return self;
     }
 
     pub fn close(self: *Self) void {
         self.allocator.destroy(self.read_buf);
-        self.file.close();
+        self.file.close(self.io_handle);
     }
 
     pub fn getNumAtoms(self: *const Self) i32 {
@@ -286,7 +287,7 @@ pub const TrrReader = struct {
         return header;
     }
 
-    inline fn io(self: *Self) *std.io.Reader {
+    inline fn io(self: *Self) *std.Io.Reader {
         return &self.reader.interface;
     }
 
@@ -335,7 +336,7 @@ pub const TrrReader = struct {
         self.io().discardAll(count) catch |err| return mapIoError(err);
     }
 
-    fn mapIoError(err: std.io.Reader.Error) TrrError {
+    fn mapIoError(err: std.Io.Reader.Error) TrrError {
         return switch (err) {
             error.EndOfStream => TrrError.EndOfFile,
             error.ReadFailed => TrrError.ReadError,
@@ -376,8 +377,9 @@ const WRITE_BUF_SIZE = 65536;
 
 /// TRR file writer (single-precision output)
 pub const TrrWriter = struct {
-    file: std.fs.File,
-    writer: std.fs.File.Writer,
+    io_handle: std.Io,
+    file: std.Io.File,
+    writer: std.Io.File.Writer,
     write_buf: *[WRITE_BUF_SIZE]u8,
     allocator: Allocator,
     natoms: i32,
@@ -386,51 +388,53 @@ pub const TrrWriter = struct {
 
     pub const Mode = enum { write, append };
 
-    pub fn open(allocator: Allocator, path: []const u8, natoms: i32, mode: Mode) !Self {
+    pub fn open(io_handle: std.Io, allocator: Allocator, path: []const u8, natoms: i32, mode: Mode) !Self {
         if (natoms <= 0) return TrrError.InvalidAtomCount;
 
         switch (mode) {
             .write => {
-                const file = std.fs.cwd().createFile(path, .{}) catch |err| {
+                const file = std.Io.Dir.cwd().createFile(io_handle, path, .{}) catch |err| {
                     return switch (err) {
                         error.FileNotFound => TrrError.FileNotFound,
                         else => TrrError.WriteError,
                     };
                 };
-                errdefer file.close();
+                errdefer file.close(io_handle);
 
                 const write_buf = allocator.create([WRITE_BUF_SIZE]u8) catch return TrrError.OutOfMemory;
                 errdefer allocator.destroy(write_buf);
 
                 return Self{
+                    .io_handle = io_handle,
                     .file = file,
-                    .writer = file.writer(write_buf),
+                    .writer = file.writer(io_handle, write_buf),
                     .write_buf = write_buf,
                     .allocator = allocator,
                     .natoms = natoms,
                 };
             },
             .append => {
-                const file = std.fs.cwd().openFile(path, .{ .mode = .read_write }) catch |err| {
+                const file = std.Io.Dir.cwd().openFile(io_handle, path, .{ .mode = .read_write }) catch |err| {
                     return switch (err) {
                         error.FileNotFound => TrrError.FileNotFound,
                         else => TrrError.WriteError,
                     };
                 };
-                errdefer file.close();
+                errdefer file.close(io_handle);
 
                 const write_buf = allocator.create([WRITE_BUF_SIZE]u8) catch return TrrError.OutOfMemory;
                 errdefer allocator.destroy(write_buf);
 
                 // Validate natoms from existing file and get file size
-                const file_size = file.getEndPos() catch return TrrError.ReadError;
+                const file_size = file.length(io_handle) catch return TrrError.ReadError;
                 if (file_size > 0) {
                     const read_buf = allocator.create([READ_BUF_SIZE]u8) catch return TrrError.OutOfMemory;
                     defer allocator.destroy(read_buf);
 
                     var temp_reader = TrrReader{
+                        .io_handle = io_handle,
                         .file = file,
-                        .reader = file.reader(read_buf),
+                        .reader = file.reader(io_handle, read_buf),
                         .read_buf = read_buf,
                         .allocator = allocator,
                         .natoms = 0,
@@ -443,10 +447,11 @@ pub const TrrWriter = struct {
 
                 // Use positional writer: set pos to end of file so writes
                 // append without disturbing the OS seek position.
-                var w = file.writer(write_buf);
+                var w = file.writer(io_handle, write_buf);
                 w.pos = file_size;
 
                 return Self{
+                    .io_handle = io_handle,
                     .file = file,
                     .writer = w,
                     .write_buf = write_buf,
@@ -460,7 +465,7 @@ pub const TrrWriter = struct {
     pub fn close(self: *Self) !void {
         const flush_result = self.writer.interface.flush();
         self.allocator.destroy(self.write_buf);
-        self.file.close();
+        self.file.close(self.io_handle);
         flush_result catch return TrrError.WriteError;
     }
 
@@ -641,14 +646,14 @@ pub const TrrWriter = struct {
 
 test "TrrReader open non-existent file" {
     const allocator = std.testing.allocator;
-    const result = TrrReader.open(allocator, "non_existent.trr");
+    const result = TrrReader.open(std.testing.io, allocator, "non_existent.trr");
     try std.testing.expectError(TrrError.FileNotFound, result);
 }
 
 test "read frame0.trr first frame" {
     const allocator = std.testing.allocator;
 
-    var reader = try TrrReader.open(allocator, "test_data/frame0.trr");
+    var reader = try TrrReader.open(std.testing.io, allocator, "test_data/frame0.trr");
     defer reader.close();
 
     // frame0.trr has 22 atoms
@@ -689,7 +694,7 @@ test "read frame0.trr first frame" {
 test "read frame0.trr all frames" {
     const allocator = std.testing.allocator;
 
-    var reader = try TrrReader.open(allocator, "test_data/frame0.trr");
+    var reader = try TrrReader.open(std.testing.io, allocator, "test_data/frame0.trr");
     defer reader.close();
 
     var frame_count: usize = 0;
@@ -711,7 +716,7 @@ test "read frame0.trr all frames" {
 test "read frame0.trr last frame" {
     const allocator = std.testing.allocator;
 
-    var reader = try TrrReader.open(allocator, "test_data/frame0.trr");
+    var reader = try TrrReader.open(std.testing.io, allocator, "test_data/frame0.trr");
     defer reader.close();
 
     const tolerance: f32 = 0.01;
@@ -757,7 +762,7 @@ test "TrrWriter write and read back single frame" {
 
     // Write a frame
     {
-        var writer = try TrrWriter.open(allocator, tmp_path, 3, .write);
+        var writer = try TrrWriter.open(std.testing.io, allocator, tmp_path, 3, .write);
         defer writer.close() catch {};
 
         const coords = [_]f32{ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0 };
@@ -781,9 +786,9 @@ test "TrrWriter write and read back single frame" {
     }
 
     // Read it back
-    defer std.fs.cwd().deleteFile(tmp_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, tmp_path) catch {};
 
-    var reader = try TrrReader.open(allocator, tmp_path);
+    var reader = try TrrReader.open(std.testing.io, allocator, tmp_path);
     defer reader.close();
 
     try std.testing.expectEqual(@as(i32, 3), reader.getNumAtoms());
@@ -810,7 +815,7 @@ test "TrrWriter write frame with x, v, f" {
     const tmp_path = "test_data/trr_tmp_write_xvf.trr";
 
     {
-        var writer = try TrrWriter.open(allocator, tmp_path, 2, .write);
+        var writer = try TrrWriter.open(std.testing.io, allocator, tmp_path, 2, .write);
         defer writer.close() catch {};
 
         const coords = [_]f32{ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
@@ -831,9 +836,9 @@ test "TrrWriter write frame with x, v, f" {
         try writer.writeFrame(frame);
     }
 
-    defer std.fs.cwd().deleteFile(tmp_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, tmp_path) catch {};
 
-    var reader = try TrrReader.open(allocator, tmp_path);
+    var reader = try TrrReader.open(std.testing.io, allocator, tmp_path);
     defer reader.close();
 
     var frame = try reader.readFrame();
@@ -852,7 +857,7 @@ test "TrrWriter write multiple frames" {
     const tmp_path = "test_data/trr_tmp_write_multi.trr";
 
     {
-        var writer = try TrrWriter.open(allocator, tmp_path, 2, .write);
+        var writer = try TrrWriter.open(std.testing.io, allocator, tmp_path, 2, .write);
         defer writer.close() catch {};
 
         for (0..5) |i| {
@@ -876,9 +881,9 @@ test "TrrWriter write multiple frames" {
         }
     }
 
-    defer std.fs.cwd().deleteFile(tmp_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, tmp_path) catch {};
 
-    var reader = try TrrReader.open(allocator, tmp_path);
+    var reader = try TrrReader.open(std.testing.io, allocator, tmp_path);
     defer reader.close();
 
     var count: usize = 0;
@@ -900,7 +905,7 @@ test "TrrWriter append mode" {
 
     // Write 2 frames
     {
-        var writer = try TrrWriter.open(allocator, tmp_path, 1, .write);
+        var writer = try TrrWriter.open(std.testing.io, allocator, tmp_path, 1, .write);
         defer writer.close() catch {};
 
         for (0..2) |i| {
@@ -923,7 +928,7 @@ test "TrrWriter append mode" {
 
     // Append 3 more frames
     {
-        var writer = try TrrWriter.open(allocator, tmp_path, 1, .append);
+        var writer = try TrrWriter.open(std.testing.io, allocator, tmp_path, 1, .append);
         defer writer.close() catch {};
 
         for (2..5) |i| {
@@ -944,10 +949,10 @@ test "TrrWriter append mode" {
         }
     }
 
-    defer std.fs.cwd().deleteFile(tmp_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, tmp_path) catch {};
 
     // Read all 5 frames
-    var reader = try TrrReader.open(allocator, tmp_path);
+    var reader = try TrrReader.open(std.testing.io, allocator, tmp_path);
     defer reader.close();
 
     var count: usize = 0;
@@ -967,10 +972,10 @@ test "TrrWriter rejects mismatched array length" {
     const allocator = std.testing.allocator;
     const tmp_path = "test_data/trr_tmp_write_err.trr";
 
-    var writer = try TrrWriter.open(allocator, tmp_path, 2, .write);
+    var writer = try TrrWriter.open(std.testing.io, allocator, tmp_path, 2, .write);
     defer {
         writer.close() catch {};
-        std.fs.cwd().deleteFile(tmp_path) catch {};
+        std.Io.Dir.cwd().deleteFile(std.testing.io, tmp_path) catch {};
     }
 
     // coords has 3 elements but natoms=2 expects 6
@@ -994,10 +999,10 @@ test "TrrWriter rejects has_x=true with null coords" {
     const allocator = std.testing.allocator;
     const tmp_path = "test_data/trr_tmp_write_null.trr";
 
-    var writer = try TrrWriter.open(allocator, tmp_path, 1, .write);
+    var writer = try TrrWriter.open(std.testing.io, allocator, tmp_path, 1, .write);
     defer {
         writer.close() catch {};
-        std.fs.cwd().deleteFile(tmp_path) catch {};
+        std.Io.Dir.cwd().deleteFile(std.testing.io, tmp_path) catch {};
     }
 
     const frame = TrrFrame{
@@ -1021,7 +1026,7 @@ test "TrrWriter append rejects natoms mismatch" {
 
     // Write with natoms=2
     {
-        var writer = try TrrWriter.open(allocator, tmp_path, 2, .write);
+        var writer = try TrrWriter.open(std.testing.io, allocator, tmp_path, 2, .write);
         defer writer.close() catch {};
         const coords = [_]f32{ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
         const frame = TrrFrame{
@@ -1038,10 +1043,10 @@ test "TrrWriter append rejects natoms mismatch" {
         };
         try writer.writeFrame(frame);
     }
-    defer std.fs.cwd().deleteFile(tmp_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, tmp_path) catch {};
 
     // Try to append with natoms=3 — should fail
-    const result = TrrWriter.open(allocator, tmp_path, 3, .append);
+    const result = TrrWriter.open(std.testing.io, allocator, tmp_path, 3, .append);
     try std.testing.expectError(TrrError.InvalidAtomCount, result);
 }
 
@@ -1051,12 +1056,12 @@ test "TrrWriter round-trip with frame0.trr" {
 
     // Read original and write all frames to new file
     {
-        var reader = try TrrReader.open(allocator, "test_data/frame0.trr");
+        var reader = try TrrReader.open(std.testing.io, allocator, "test_data/frame0.trr");
         defer reader.close();
 
         const natoms = reader.getNumAtoms();
 
-        var writer = try TrrWriter.open(allocator, tmp_path, natoms, .write);
+        var writer = try TrrWriter.open(std.testing.io, allocator, tmp_path, natoms, .write);
         defer writer.close() catch {};
 
         while (true) {
@@ -1069,13 +1074,13 @@ test "TrrWriter round-trip with frame0.trr" {
         }
     }
 
-    defer std.fs.cwd().deleteFile(tmp_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, tmp_path) catch {};
 
     // Read back and compare with original
-    var reader_orig = try TrrReader.open(allocator, "test_data/frame0.trr");
+    var reader_orig = try TrrReader.open(std.testing.io, allocator, "test_data/frame0.trr");
     defer reader_orig.close();
 
-    var reader_copy = try TrrReader.open(allocator, tmp_path);
+    var reader_copy = try TrrReader.open(std.testing.io, allocator, tmp_path);
     defer reader_copy.close();
 
     try std.testing.expectEqual(reader_orig.getNumAtoms(), reader_copy.getNumAtoms());
@@ -1131,18 +1136,18 @@ test "TrrWriter round-trip with frame0.trr" {
 
 test "TrrWriter rejects natoms <= 0" {
     const allocator = std.testing.allocator;
-    try std.testing.expectError(TrrError.InvalidAtomCount, TrrWriter.open(allocator, "test_data/trr_tmp_zero.trr", 0, .write));
-    try std.testing.expectError(TrrError.InvalidAtomCount, TrrWriter.open(allocator, "test_data/trr_tmp_neg.trr", -1, .write));
+    try std.testing.expectError(TrrError.InvalidAtomCount, TrrWriter.open(std.testing.io, allocator, "test_data/trr_tmp_zero.trr", 0, .write));
+    try std.testing.expectError(TrrError.InvalidAtomCount, TrrWriter.open(std.testing.io, allocator, "test_data/trr_tmp_neg.trr", -1, .write));
 }
 
 test "TrrWriter rejects has_v=true with null velocities" {
     const allocator = std.testing.allocator;
     const tmp_path = "test_data/trr_tmp_write_null_v.trr";
 
-    var writer = try TrrWriter.open(allocator, tmp_path, 1, .write);
+    var writer = try TrrWriter.open(std.testing.io, allocator, tmp_path, 1, .write);
     defer {
         writer.close() catch {};
-        std.fs.cwd().deleteFile(tmp_path) catch {};
+        std.Io.Dir.cwd().deleteFile(std.testing.io, tmp_path) catch {};
     }
 
     const coords = [_]f32{ 1.0, 2.0, 3.0 };
@@ -1165,10 +1170,10 @@ test "TrrWriter rejects has_f=true with null forces" {
     const allocator = std.testing.allocator;
     const tmp_path = "test_data/trr_tmp_write_null_f.trr";
 
-    var writer = try TrrWriter.open(allocator, tmp_path, 1, .write);
+    var writer = try TrrWriter.open(std.testing.io, allocator, tmp_path, 1, .write);
     defer {
         writer.close() catch {};
-        std.fs.cwd().deleteFile(tmp_path) catch {};
+        std.Io.Dir.cwd().deleteFile(std.testing.io, tmp_path) catch {};
     }
 
     const coords = [_]f32{ 1.0, 2.0, 3.0 };

--- a/src/xdrfile_trr.zig
+++ b/src/xdrfile_trr.zig
@@ -128,7 +128,7 @@ pub const TrrReader = struct {
         const header = try self.readHeader();
         self.natoms = header.natoms;
 
-        // Reset to beginning
+        // Rewind: we consumed the first header just to learn natoms; replay from byte 0.
         self.reader.seekTo(0) catch return TrrError.ReadError;
 
         return self;

--- a/src/xdrfile_xtc.zig
+++ b/src/xdrfile_xtc.zig
@@ -325,9 +325,9 @@ pub const XtcReader = struct {
         if (magic != XTC_MAGIC) return XtcError.InvalidMagic;
 
         self.natoms = self.readInt() catch return XtcError.ReadError;
-        if (self.natoms <= 0) return XtcError.ReadError;
+        if (self.natoms <= 0) return XtcError.InvalidAtomCount;
 
-        // Reset to beginning
+        // Rewind: we consumed the first header just to learn natoms; replay from byte 0.
         self.reader.seekTo(0) catch return XtcError.ReadError;
 
         // Allocate decompression buffers

--- a/src/xdrfile_xtc.zig
+++ b/src/xdrfile_xtc.zig
@@ -286,8 +286,9 @@ fn encodeints(buf: []i32, num_of_ints: usize, num_of_bits: u32, sizes: []const u
 
 /// XTC file reader
 pub const XtcReader = struct {
-    file: std.fs.File,
-    reader: std.fs.File.Reader,
+    io_handle: std.Io,
+    file: std.Io.File,
+    reader: std.Io.File.Reader,
     read_buf: *[READ_BUF_SIZE]u8,
     allocator: Allocator,
     natoms: i32,
@@ -298,16 +299,17 @@ pub const XtcReader = struct {
 
     const Self = @This();
 
-    pub fn open(allocator: Allocator, path: []const u8) !Self {
-        const file = std.fs.cwd().openFile(path, .{}) catch {
+    pub fn open(io_handle: std.Io, allocator: Allocator, path: []const u8) !Self {
+        const file = std.Io.Dir.cwd().openFile(io_handle, path, .{}) catch {
             return XtcError.FileNotFound;
         };
-        errdefer file.close();
+        errdefer file.close(io_handle);
 
         const read_buf = allocator.create([READ_BUF_SIZE]u8) catch return XtcError.OutOfMemory;
         errdefer allocator.destroy(read_buf);
 
         var self = Self{
+            .io_handle = io_handle,
             .file = file,
             .reader = undefined,
             .read_buf = read_buf,
@@ -316,7 +318,7 @@ pub const XtcReader = struct {
             .buf1 = &[_]i32{},
             .buf2 = &[_]i32{},
         };
-        self.reader = file.reader(read_buf);
+        self.reader = file.reader(io_handle, read_buf);
 
         // Read first frame header to get natoms
         const magic = self.readInt() catch return XtcError.ReadError;
@@ -326,8 +328,7 @@ pub const XtcReader = struct {
         if (self.natoms <= 0) return XtcError.ReadError;
 
         // Reset to beginning
-        file.seekTo(0) catch return XtcError.ReadError;
-        self.reader = file.reader(read_buf);
+        self.reader.seekTo(0) catch return XtcError.ReadError;
 
         // Allocate decompression buffers
         const natoms_u: usize = @intCast(self.natoms);
@@ -345,7 +346,7 @@ pub const XtcReader = struct {
         self.allocator.free(self.buf1);
         self.allocator.free(self.buf2);
         self.allocator.destroy(self.read_buf);
-        self.file.close();
+        self.file.close(self.io_handle);
     }
 
     pub fn getNumAtoms(self: *const Self) i32 {
@@ -402,11 +403,11 @@ pub const XtcReader = struct {
     // XDR I/O (big-endian, 4 bytes per element)
     // ============================================
 
-    inline fn io(self: *Self) *std.io.Reader {
+    inline fn io(self: *Self) *std.Io.Reader {
         return &self.reader.interface;
     }
 
-    fn mapIoError(err: std.io.Reader.Error) XtcError {
+    fn mapIoError(err: std.Io.Reader.Error) XtcError {
         return switch (err) {
             error.EndOfStream => XtcError.EndOfFile,
             error.ReadFailed => XtcError.ReadError,
@@ -652,8 +653,9 @@ const WRITE_BUF_SIZE = 65536;
 
 /// XTC file writer (single-precision with coordinate compression)
 pub const XtcWriter = struct {
-    file: std.fs.File,
-    writer: std.fs.File.Writer,
+    io_handle: std.Io,
+    file: std.Io.File,
+    writer: std.Io.File.Writer,
     write_buf: *[WRITE_BUF_SIZE]u8,
     allocator: Allocator,
     natoms: i32,
@@ -666,7 +668,7 @@ pub const XtcWriter = struct {
 
     pub const Mode = enum { write, append };
 
-    pub fn open(allocator: Allocator, path: []const u8, natoms: i32, mode: Mode) !Self {
+    pub fn open(io_handle: std.Io, allocator: Allocator, path: []const u8, natoms: i32, mode: Mode) !Self {
         if (natoms <= 0) return XtcError.InvalidAtomCount;
 
         const natoms_u: usize = @intCast(natoms);
@@ -683,20 +685,21 @@ pub const XtcWriter = struct {
 
         switch (mode) {
             .write => {
-                const file = std.fs.cwd().createFile(path, .{}) catch |err| {
+                const file = std.Io.Dir.cwd().createFile(io_handle, path, .{}) catch |err| {
                     return switch (err) {
                         error.FileNotFound => XtcError.FileNotFound,
                         else => XtcError.WriteError,
                     };
                 };
-                errdefer file.close();
+                errdefer file.close(io_handle);
 
                 const write_buf = allocator.create([WRITE_BUF_SIZE]u8) catch return XtcError.OutOfMemory;
                 errdefer allocator.destroy(write_buf);
 
                 return Self{
+                    .io_handle = io_handle,
                     .file = file,
-                    .writer = file.writer(write_buf),
+                    .writer = file.writer(io_handle, write_buf),
                     .write_buf = write_buf,
                     .allocator = allocator,
                     .natoms = natoms,
@@ -705,24 +708,24 @@ pub const XtcWriter = struct {
                 };
             },
             .append => {
-                const file = std.fs.cwd().openFile(path, .{ .mode = .read_write }) catch |err| {
+                const file = std.Io.Dir.cwd().openFile(io_handle, path, .{ .mode = .read_write }) catch |err| {
                     return switch (err) {
                         error.FileNotFound => XtcError.FileNotFound,
                         else => XtcError.WriteError,
                     };
                 };
-                errdefer file.close();
+                errdefer file.close(io_handle);
 
                 const write_buf = allocator.create([WRITE_BUF_SIZE]u8) catch return XtcError.OutOfMemory;
                 errdefer allocator.destroy(write_buf);
 
                 // Validate natoms from existing file, then seek to end
-                const file_size = file.getEndPos() catch return XtcError.ReadError;
+                const file_size = file.length(io_handle) catch return XtcError.ReadError;
                 if (file_size > 0) {
                     const read_buf = allocator.create([READ_BUF_SIZE]u8) catch return XtcError.OutOfMemory;
                     defer allocator.destroy(read_buf);
 
-                    var temp_reader = file.reader(read_buf);
+                    var temp_reader = file.reader(io_handle, read_buf);
                     const magic_buf = temp_reader.interface.takeArray(4) catch return XtcError.ReadError;
                     const magic: i32 = @bitCast(std.mem.readInt(u32, magic_buf, .big));
                     if (magic != XTC_MAGIC) return XtcError.InvalidMagic;
@@ -733,10 +736,11 @@ pub const XtcWriter = struct {
                 }
 
                 // Use positional writer: set pos to end of file so writes append
-                var w = file.writer(write_buf);
+                var w = file.writer(io_handle, write_buf);
                 w.pos = file_size;
 
                 return Self{
+                    .io_handle = io_handle,
                     .file = file,
                     .writer = w,
                     .write_buf = write_buf,
@@ -756,7 +760,7 @@ pub const XtcWriter = struct {
         self.allocator.free(self.buf1);
         self.allocator.free(self.buf2);
         self.allocator.destroy(self.write_buf);
-        self.file.close();
+        self.file.close(self.io_handle);
         flush_result catch return XtcError.WriteError;
     }
 
@@ -1102,7 +1106,7 @@ test "magicints table" {
 test "read 1l2y.xtc first frame" {
     const allocator = std.testing.allocator;
 
-    var reader = try XtcReader.open(allocator, "test_data/1l2y.xtc");
+    var reader = try XtcReader.open(std.testing.io, allocator, "test_data/1l2y.xtc");
     defer reader.close();
 
     const natoms = reader.getNumAtoms();
@@ -1144,7 +1148,7 @@ test "read 1l2y.xtc first frame" {
 test "read 1l2y.xtc all frames" {
     const allocator = std.testing.allocator;
 
-    var reader = try XtcReader.open(allocator, "test_data/1l2y.xtc");
+    var reader = try XtcReader.open(std.testing.io, allocator, "test_data/1l2y.xtc");
     defer reader.close();
 
     var frame_count: usize = 0;
@@ -1165,7 +1169,7 @@ test "read 1l2y.xtc all frames" {
 test "read large xtc (6qfk 90MB)" {
     const allocator = std.testing.allocator;
 
-    var reader = XtcReader.open(allocator, "benchmarks/md_data/6qfk_A_analysis/6qfk_A_R1.xtc") catch |err| {
+    var reader = XtcReader.open(std.testing.io, allocator, "benchmarks/md_data/6qfk_A_analysis/6qfk_A_R1.xtc") catch |err| {
         if (err == error.FileNotFound) return;
         return err;
     };
@@ -1209,7 +1213,7 @@ test "read large xtc (6qfk 90MB)" {
 test "read very large xtc (5ltj 511MB)" {
     const allocator = std.testing.allocator;
 
-    var reader = XtcReader.open(allocator, "benchmarks/md_data/5ltj_A_protein/5ltj_A_prod_R1_fit.xtc") catch |err| {
+    var reader = XtcReader.open(std.testing.io, allocator, "benchmarks/md_data/5ltj_A_protein/5ltj_A_prod_R1_fit.xtc") catch |err| {
         if (err == error.FileNotFound) return;
         return err;
     };
@@ -1251,7 +1255,7 @@ test "XtcWriter round-trip: 3 atoms (small path, no compression)" {
     const tmp_path = "test_data/xtc_tmp_xtc_write_3.xtc";
 
     {
-        var writer = try XtcWriter.open(allocator, tmp_path, 3, .write);
+        var writer = try XtcWriter.open(std.testing.io, allocator, tmp_path, 3, .write);
         defer writer.close() catch {};
 
         var coords = [_]f32{ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0 };
@@ -1269,9 +1273,9 @@ test "XtcWriter round-trip: 3 atoms (small path, no compression)" {
         try writer.writeFrame(frame);
     }
 
-    defer std.fs.cwd().deleteFile(tmp_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, tmp_path) catch {};
 
-    var reader = try XtcReader.open(allocator, tmp_path);
+    var reader = try XtcReader.open(std.testing.io, allocator, tmp_path);
     defer reader.close();
 
     try std.testing.expectEqual(@as(i32, 3), reader.getNumAtoms());
@@ -1303,7 +1307,7 @@ test "XtcWriter round-trip: 20 atoms (full compression path)" {
     }
 
     {
-        var writer = try XtcWriter.open(allocator, tmp_path, natoms, .write);
+        var writer = try XtcWriter.open(std.testing.io, allocator, tmp_path, natoms, .write);
         defer writer.close() catch {};
 
         const frame = XtcFrame{
@@ -1320,9 +1324,9 @@ test "XtcWriter round-trip: 20 atoms (full compression path)" {
         try writer.writeFrame(frame);
     }
 
-    defer std.fs.cwd().deleteFile(tmp_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, tmp_path) catch {};
 
-    var reader = try XtcReader.open(allocator, tmp_path);
+    var reader = try XtcReader.open(std.testing.io, allocator, tmp_path);
     defer reader.close();
 
     try std.testing.expectEqual(@as(i32, natoms), reader.getNumAtoms());
@@ -1356,7 +1360,7 @@ test "XtcWriter multi-frame: write 5 frames, verify step and coord values" {
     }
 
     {
-        var writer = try XtcWriter.open(allocator, tmp_path, natoms, .write);
+        var writer = try XtcWriter.open(std.testing.io, allocator, tmp_path, natoms, .write);
         defer writer.close() catch {};
 
         for (0..num_frames) |f| {
@@ -1375,9 +1379,9 @@ test "XtcWriter multi-frame: write 5 frames, verify step and coord values" {
         }
     }
 
-    defer std.fs.cwd().deleteFile(tmp_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, tmp_path) catch {};
 
-    var reader = try XtcReader.open(allocator, tmp_path);
+    var reader = try XtcReader.open(std.testing.io, allocator, tmp_path);
     defer reader.close();
 
     try std.testing.expectEqual(@as(i32, natoms), reader.getNumAtoms());
@@ -1416,7 +1420,7 @@ test "XtcWriter append mode: write 2 then append 3, read all 5" {
 
     // Write first 2 frames
     {
-        var writer = try XtcWriter.open(allocator, tmp_path, natoms, .write);
+        var writer = try XtcWriter.open(std.testing.io, allocator, tmp_path, natoms, .write);
         defer writer.close() catch {};
 
         for (0..2) |f| {
@@ -1437,7 +1441,7 @@ test "XtcWriter append mode: write 2 then append 3, read all 5" {
 
     // Append 3 more frames
     {
-        var writer = try XtcWriter.open(allocator, tmp_path, natoms, .append);
+        var writer = try XtcWriter.open(std.testing.io, allocator, tmp_path, natoms, .append);
         defer writer.close() catch {};
 
         for (2..5) |f| {
@@ -1456,9 +1460,9 @@ test "XtcWriter append mode: write 2 then append 3, read all 5" {
         }
     }
 
-    defer std.fs.cwd().deleteFile(tmp_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, tmp_path) catch {};
 
-    var reader = try XtcReader.open(allocator, tmp_path);
+    var reader = try XtcReader.open(std.testing.io, allocator, tmp_path);
     defer reader.close();
 
     try std.testing.expectEqual(@as(i32, natoms), reader.getNumAtoms());
@@ -1489,7 +1493,7 @@ test "XtcWriter round-trip with 1l2y.xtc (304 atoms, all 38 frames)" {
     var src_frame_count: usize = 0;
 
     {
-        var src_reader = try XtcReader.open(allocator, src_path);
+        var src_reader = try XtcReader.open(std.testing.io, allocator, src_path);
         defer src_reader.close();
 
         const natoms = src_reader.getNumAtoms();
@@ -1517,7 +1521,7 @@ test "XtcWriter round-trip with 1l2y.xtc (304 atoms, all 38 frames)" {
 
     // Write all frames to a temporary file
     {
-        var writer = try XtcWriter.open(allocator, tmp_path, @as(i32, 304), .write);
+        var writer = try XtcWriter.open(std.testing.io, allocator, tmp_path, @as(i32, 304), .write);
         defer writer.close() catch {};
 
         for (0..src_frame_count) |i| {
@@ -1525,10 +1529,10 @@ test "XtcWriter round-trip with 1l2y.xtc (304 atoms, all 38 frames)" {
         }
     }
 
-    defer std.fs.cwd().deleteFile(tmp_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, tmp_path) catch {};
 
     // Read back and compare every frame coordinate-by-coordinate
-    var dst_reader = try XtcReader.open(allocator, tmp_path);
+    var dst_reader = try XtcReader.open(std.testing.io, allocator, tmp_path);
     defer dst_reader.close();
 
     try std.testing.expectEqual(@as(i32, 304), dst_reader.getNumAtoms());
@@ -1556,10 +1560,10 @@ test "XtcWriter error paths" {
 
     // natoms <= 0 must return InvalidAtomCount
     {
-        const result = XtcWriter.open(allocator, "test_data/xtc_tmp_xtc_err_zero.xtc", 0, .write);
+        const result = XtcWriter.open(std.testing.io, allocator, "test_data/xtc_tmp_xtc_err_zero.xtc", 0, .write);
         try std.testing.expectError(XtcError.InvalidAtomCount, result);
 
-        const result_neg = XtcWriter.open(allocator, "test_data/xtc_tmp_xtc_err_neg.xtc", -5, .write);
+        const result_neg = XtcWriter.open(std.testing.io, allocator, "test_data/xtc_tmp_xtc_err_neg.xtc", -5, .write);
         try std.testing.expectError(XtcError.InvalidAtomCount, result_neg);
     }
 
@@ -1567,9 +1571,9 @@ test "XtcWriter error paths" {
     {
         const tmp_path = "test_data/xtc_tmp_xtc_err_coords.xtc";
 
-        var writer = try XtcWriter.open(allocator, tmp_path, 20, .write);
+        var writer = try XtcWriter.open(std.testing.io, allocator, tmp_path, 20, .write);
         defer writer.close() catch {};
-        defer std.fs.cwd().deleteFile(tmp_path) catch {};
+        defer std.Io.Dir.cwd().deleteFile(std.testing.io, tmp_path) catch {};
 
         // Provide only 3 coords instead of 60
         var short_coords = [_]f32{ 1.0, 2.0, 3.0 };
@@ -1594,7 +1598,7 @@ test "XtcWriter error paths" {
 
         // Create file with natoms=20
         {
-            var writer = try XtcWriter.open(allocator, tmp_path, 20, .write);
+            var writer = try XtcWriter.open(std.testing.io, allocator, tmp_path, 20, .write);
             defer writer.close() catch {};
 
             var coords: [20 * 3]f32 = undefined;
@@ -1613,10 +1617,10 @@ test "XtcWriter error paths" {
             try writer.writeFrame(frame);
         }
 
-        defer std.fs.cwd().deleteFile(tmp_path) catch {};
+        defer std.Io.Dir.cwd().deleteFile(std.testing.io, tmp_path) catch {};
 
         // Try to append with natoms=10 (mismatch — file has 20)
-        const append_result = XtcWriter.open(allocator, tmp_path, 10, .append);
+        const append_result = XtcWriter.open(std.testing.io, allocator, tmp_path, 10, .append);
         try std.testing.expectError(XtcError.InvalidAtomCount, append_result);
     }
 }


### PR DESCRIPTION
## Summary

- Adapt to Zig 0.16's unified I/O interface (`std.Io`).
- All reader/writer entry points (`XtcReader.open`, `XtcWriter.open`, `TrrReader.open`, `TrrWriter.open`) gain a new first parameter `io: std.Io`.
- `converter` and `benchmark` migrated to the `pub fn main(init: std.process.Init)` convention.
- Bump `minimum_zig_version` 0.15.2 → 0.16.0; package version 0.2.0 → 0.3.0.

## Breaking change

Callers must thread `io` through the API. Obtain it from `std.process.Init.io` in `main`, or use `std.testing.io` in tests.

```zig
// Before (0.2.x)
var reader = try XtcReader.open(allocator, "traj.xtc");

// After (0.3.0)
var reader = try XtcReader.open(io, allocator, "traj.xtc");
```

CHANGELOG.md has the full migration note.

## Internal API mapping

| 0.15.x | 0.16 |
|---|---|
| `std.heap.GeneralPurposeAllocator` | `std.heap.DebugAllocator` |
| `std.fs.cwd()` / `std.fs.File` | `std.Io.Dir.cwd()` / `std.Io.File` |
| `std.io.Reader` | `std.Io.Reader` |
| `std.process.argsAlloc` | `std.process.Init.minimal.args.toSlice` |
| `std.time.Timer` | `std.Io.Timestamp` + `Clock.awake` |
| `file.getEndPos` / `file.seekTo` | `file.length(io)` / `Reader.seekTo` |

## Test plan

- [x] `zig build test` — 29/29 pass
- [x] `zig build validate` — 31/31 pass
- [x] `zig build cross-format` — 32/32 pass
- [x] `converter trr_to_xtc test_data/frame0.trr /tmp/out.xtc` succeeds (501 frames)
- [ ] CI green on GitHub Actions (Zig 0.16.0)