### PR TITLE
ci: add macos-latest to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
@@ -29,3 +33,6 @@ jobs:
 
       - name: Run validation tests
         run: zig build validate
+
+      - name: Run cross-format tests
+        run: zig build cross-format


### PR DESCRIPTION
## Summary

- Run CI on both \`ubuntu-latest\` and \`macos-latest\` so the \`std.Io\` backends on Linux (io_uring/epoll) and macOS (kqueue) both stay green.
- Also include \`zig build cross-format\` which was previously skipped.

Closes #29.

## Test plan

- [ ] Both Linux and macOS jobs go green on this branch