### PR TITLE
release: v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
-## [Unreleased]
+## [0.4.0] - 2026-04-26
 
 ### Changed
 
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   `AccessDenied`, `IsDir`, `NoSpaceLeft`, and `IoError` variants.
   `XtcError` also gained `InvalidHeader` for truncated headers on append.
   Previously these were all collapsed into `FileNotFound`/`ReadError`/`WriteError`,
-  which made debugging open/create failures impossible.
+  which made debugging open/create failures impossible. (#25, #26, #27)
 - `XtcReader.open` and `TrrReader.open` now reject directories at open time
   (via `allow_directory = false`) instead of failing later with a generic
   `ReadError`. (#25)
@@ -25,9 +25,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - `benchmark` now logs non-FileNotFound failures (corrupt JSON, permission
   errors) instead of silently skipping them. (#28)
 
-### Fixed
+### Added
 
-- Closes #25, #26, #27, #28.
+- macOS to CI matrix and run cross-format tests on every push (#31, #29)
+- `zig build converter-smoke` end-to-end smoke test of the converter binary
+  exercising the full `std.process.Init` plumbing (#33, #30)
+- IsDir tests for both readers and writers
+
+### Compatibility
+
+The new error variants are technically additive, but exhaustive switches over
+`XtcError` / `TrrError` will need new arms — hence minor bump.
 
 ## [0.3.0] - 2026-04-26
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zxdrfile,
-    .version = "0.3.0",
+    .version = "0.4.0",
     .fingerprint = 0x3a99db92f6908624,
     .minimum_zig_version = "0.16.0",
     .paths = .{


### PR DESCRIPTION
## v0.4.0 — 2026-04-26

### Changed

- **More accurate error reporting**: \`XtcError\` and \`TrrError\` gained \`AccessDenied\`, \`IsDir\`, \`NoSpaceLeft\`, and \`IoError\` variants. \`XtcError\` also gained \`InvalidHeader\`. (#25, #26, #27)
- Readers now reject directories at open time via \`allow_directory = false\`. (#25)
- Writer append paths preserve \`InvalidMagic\` / \`InvalidHeader\` instead of collapsing to \`ReadError\`. (#26)
- benchmark logs non-FileNotFound failures instead of silent skip. (#28)

### Added

- macOS in CI matrix and cross-format tests run on every push (#29, #31)
- \`zig build converter-smoke\` end-to-end smoke test for the converter binary (#30, #33)
- IsDir tests for both readers and writers

### Compatibility

New error variants are additive, but exhaustive switches will need new arms — minor bump.

## Test plan

- [x] All test steps pass locally on macOS (test 34, validate 36, cross-format 37)
- [x] CI green on Linux + macOS