### PR TITLE
docs: mark zxdrfile as archived

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Archived] - 2026-05-21
+
+### Changed
+
+- Mark this standalone repository as archived. Ongoing trajectory I/O development
+  is now managed in [ztraj](https://github.com/N283T/ztraj).
+
 ## [0.4.0] - 2026-04-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # zxdrfile
 
+> **Archived:** This repository is now in maintenance/archive mode.
+> XTC/TRR trajectory I/O is managed as part of [ztraj](https://github.com/N283T/ztraj),
+> which is the recommended place for new development, bug fixes, and usage.
+> This repository remains available as a historical standalone Zig xdrfile implementation.
+
 [![Zig](https://img.shields.io/badge/Zig-0.16.0+-f7a41d?logo=zig&logoColor=white)](https://ziglang.org/)
 [![CI](https://github.com/N283T/zxdrfile/actions/workflows/ci.yml/badge.svg)](https://github.com/N283T/zxdrfile/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-BSD_2--Clause-blue.svg)](LICENSE)
@@ -7,6 +12,15 @@
 A high-performance Zig library for reading and writing GROMACS XDR trajectory files (XTC and TRR formats).
 
 [**API Documentation**](https://n283t.github.io/zxdrfile/)
+
+## Repository Status
+
+This standalone package has been archived because trajectory I/O is now managed
+in the unified [ztraj](https://github.com/N283T/ztraj) repository. Use ztraj for
+ongoing development and new integrations.
+
+The code here is kept for reference and for existing users pinned to zxdrfile,
+but no new feature work is planned in this repository.
 
 ## Features
 
@@ -17,6 +31,10 @@ A high-performance Zig library for reading and writing GROMACS XDR trajectory fi
 - **Append mode** -- Append frames to existing trajectory files with natoms validation
 
 ## Installation
+
+> **For new projects:** prefer [ztraj](https://github.com/N283T/ztraj).
+> The instructions below are retained for existing users who intentionally depend
+> on the archived standalone `zxdrfile` package.
 
 Add as a dependency in your `build.zig.zon`:
 


### PR DESCRIPTION
## Summary

- Mark this standalone zxdrfile repository as archived/maintenance-only
- Point new development, bug fixes, and integrations to https://github.com/N283T/ztraj
- Keep installation details for existing users pinned to the standalone package
- Record the archive status in the changelog

## Validation

- `git diff --check HEAD~1..HEAD`
